### PR TITLE
Minor issues with version flag.

### DIFF
--- a/plac_core.py
+++ b/plac_core.py
@@ -432,7 +432,7 @@ def call(obj, arglist=None, eager=True, version=None):
     parser = parser_from(obj)
     if version:
         parser.add_argument(
-            '--version', '-v', action='version', version=version)
+            '-V', '--version', action='version', version=version)
     cmd, result = parser.consume(arglist)
     if iterable(result) and eager:  # listify the result
         return list(result)


### PR DESCRIPTION
There are two minor issues when setting the version argument in the call function:

The order of the short and long version flag names in the help message that plac generates is different from all other options. Fixed this because it just looks better.

For the short name plac uses a lower case 'v' which is commonly used as an abbrevation for a verbose flag. Changed this to an upper case 'V'. This convention is followed by the Python interpreter and other programmes, e.g. pip, pytest, etc.