### PR TITLE
[DO NOT MERGE] Adjust expected test output for Python 3.13

### DIFF
--- a/doc/example13.help
+++ b/doc/example13.help
@@ -1,7 +1,7 @@
 usage: example13.py [-h] [-l] [-y] [-s 100]
 
 options:
-  -h, --help         show this help message and exit
+  -h, --help     show this help message and exit
   -l, --list
-  -y, --yield        [False]
-  -s 100, --sys 100  [100]
+  -y, --yield    [False]
+  -s, --sys 100  [100]

--- a/doc/example8.help
+++ b/doc/example8.help
@@ -5,5 +5,5 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -c COMMAND, --command COMMAND
+  -c, --command COMMAND
                         SQL query

--- a/doc/example8_.help
+++ b/doc/example8_.help
@@ -5,5 +5,5 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -c select * from table, --command select * from table
+  -c, --command select * from table
                         SQL query

--- a/doc/example_all.help
+++ b/doc/example_all.help
@@ -3,10 +3,10 @@ usage: example_all.py [-h] [-o .] [-n 100] [-d] {A,B,C}
 A script for machine learning
 
 positional arguments:
-  {A,B,C}               Model name
+  {A,B,C}             Model name
 
 options:
-  -h, --help            show this help message and exit
-  -o ., --output-dir .  Optional output directory
-  -n 100, --n-iter 100  Number of training iterations
-  -d, --debug           Enable debug mode
+  -h, --help          show this help message and exit
+  -o, --output-dir .  Optional output directory
+  -n, --n-iter 100    Number of training iterations
+  -d, --debug         Enable debug mode


### PR DESCRIPTION
This PR documents the format changes in Python 3.13. Merging it directly would fix the tests in Python 3.13 (but break them on Python 3.12 and older).